### PR TITLE
fix: prevent event propagation in onboarding analytics toggle

### DIFF
--- a/src/FirstRunWizard.tsx
+++ b/src/FirstRunWizard.tsx
@@ -257,7 +257,10 @@ function Toggle({
 }) {
   return (
     <button
-      onClick={onToggle}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
       className={`relative flex-shrink-0 w-10 h-5 rounded-full transition-colors focus:outline-none ${
         enabled ? "bg-brand" : "bg-surface-active"
       }`}


### PR DESCRIPTION
I tried to launch the app, and wasn't able to opt out of sharing analytics, which prevented me from completing onboarding. I have built and verified that this fix works, but not sure how idiomatic it is.
